### PR TITLE
fix(ci): resolve test, credo, format, and docker build failures

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -116,6 +116,9 @@ config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+# Use Req as HTTP client for ExAws (replaces hackney)
+config :ex_aws, http_client: ExAws.Request.Req
+
 config :phoenix, :json_library, Jason
 
 # Upstream configuration (stored in Mnesia database)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -57,7 +57,6 @@ config :mnesia, dir: ~c"priv/mnesia/dev"
 
 # S3 Configuration for development
 config :ex_aws,
-  http_client: ExAws.Request.Req,
   access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
   secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
   region: System.get_env("AWS_REGION", "us-east-1")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,7 +21,6 @@ config :hex_hub,
 
 # S3 Configuration for production
 config :ex_aws,
-  http_client: ExAws.Request.Req,
   access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
   secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
   region: System.get_env("AWS_REGION", "us-east-1")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -82,7 +82,6 @@ if config_env() == :prod do
       end
 
     config :ex_aws,
-      http_client: ExAws.Request.Req,
       access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
       secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
       region: System.get_env("AWS_REGION", "us-east-1")

--- a/lib/hex_hub/cached_packages.ex
+++ b/lib/hex_hub/cached_packages.ex
@@ -752,26 +752,23 @@ defmodule HexHub.CachedPackages do
         # Cache new release tarballs
         cached_count =
           Enum.count(new_releases, fn release ->
-            version = release["version"]
-
-            case HexHub.Upstream.fetch_release_tarball(name, version) do
-              {:ok, tarball} ->
-                case HexHub.Upstream.cache_package(name, version, tarball, %{}) do
-                  :ok ->
-                    create_cached_release(name, release)
-                    true
-
-                  {:error, _} ->
-                    false
-                end
-
-              {:error, _} ->
-                false
-            end
+            cache_new_release(name, release)
           end)
 
         {:ok, %{new_releases: cached_count}}
       end
+    end
+  end
+
+  defp cache_new_release(name, release) do
+    version = release["version"]
+
+    with {:ok, tarball} <- HexHub.Upstream.fetch_release_tarball(name, version),
+         :ok <- HexHub.Upstream.cache_package(name, version, tarball, %{}) do
+      create_cached_release(name, release)
+      true
+    else
+      {:error, _} -> false
     end
   end
 

--- a/lib/hex_hub/mcp/schemas.ex
+++ b/lib/hex_hub/mcp/schemas.ex
@@ -191,7 +191,7 @@ defmodule HexHub.MCP.Schemas do
     # Check required fields
     missing_fields = Enum.reject(required_fields, &Map.has_key?(data, &1))
 
-    if length(missing_fields) > 0 do
+    if missing_fields != [] do
       {:error, :missing_required_fields}
     else
       # Validate each property that has a schema

--- a/lib/hex_hub/mcp/tools/dependencies.ex
+++ b/lib/hex_hub/mcp/tools/dependencies.ex
@@ -141,7 +141,7 @@ defmodule HexHub.MCP.Tools.Dependencies do
 
     errors = Enum.filter(parsed, &match?({:error, _}, &1))
 
-    if length(errors) > 0 do
+    if errors != [] do
       {:error, {:invalid_requirements, errors}}
     else
       {:ok, Enum.into(parsed, %{})}
@@ -178,7 +178,7 @@ defmodule HexHub.MCP.Tools.Dependencies do
 
     errors = Enum.filter(resolved, &match?({:error, _}, &1))
 
-    if length(errors) > 0 do
+    if errors != [] do
       {:error, {:resolution_failed, errors}}
     else
       {:ok, Enum.filter(resolved, &match?({_, _}, &1))}
@@ -369,7 +369,7 @@ defmodule HexHub.MCP.Tools.Dependencies do
 
     errors = Enum.filter(parsed, &match?({:error, _}, &1))
 
-    if length(errors) > 0 do
+    if errors != [] do
       {:error, {:invalid_packages, errors}}
     else
       {:ok, Enum.filter(parsed, &match?({_, _}, &1))}
@@ -549,7 +549,7 @@ defmodule HexHub.MCP.Tools.Dependencies do
         not Map.has_key?(args, field) or is_nil(Map.get(args, field))
       end)
 
-    if length(missing_required) > 0 do
+    if missing_required != [] do
       {:error, {:missing_required_fields, missing_required}}
     else
       # Check for unknown fields
@@ -560,7 +560,7 @@ defmodule HexHub.MCP.Tools.Dependencies do
           field not in known_fields
         end)
 
-      if length(unknown_fields) > 0 do
+      if unknown_fields != [] do
         Telemetry.log(:warning, :mcp, "Unknown fields in args", %{
           unknown_fields: inspect(unknown_fields)
         })

--- a/lib/hex_hub/mcp/tools/documentation.ex
+++ b/lib/hex_hub/mcp/tools/documentation.ex
@@ -322,7 +322,7 @@ defmodule HexHub.MCP.Tools.Documentation do
         not Map.has_key?(args, field) or is_nil(Map.get(args, field))
       end)
 
-    if length(missing_required) > 0 do
+    if missing_required != [] do
       {:error, {:missing_required_fields, missing_required}}
     else
       # Check for unknown fields
@@ -333,7 +333,7 @@ defmodule HexHub.MCP.Tools.Documentation do
           field not in known_fields
         end)
 
-      if length(unknown_fields) > 0 do
+      if unknown_fields != [] do
         Telemetry.log(:warning, :mcp, "Unknown fields in args", %{
           unknown_fields: inspect(unknown_fields)
         })

--- a/lib/hex_hub/mcp/tools/packages.ex
+++ b/lib/hex_hub/mcp/tools/packages.ex
@@ -334,7 +334,7 @@ defmodule HexHub.MCP.Tools.Packages do
         not Map.has_key?(args, field) or is_nil(Map.get(args, field))
       end)
 
-    if length(missing_required) > 0 do
+    if missing_required != [] do
       {:error, {:missing_required_fields, missing_required}}
     else
       # Check for unknown fields
@@ -345,7 +345,7 @@ defmodule HexHub.MCP.Tools.Packages do
           field not in known_fields
         end)
 
-      if length(unknown_fields) > 0 do
+      if unknown_fields != [] do
         Telemetry.log(:warning, :mcp, "Unknown fields in args", %{
           unknown_fields: inspect(unknown_fields)
         })

--- a/lib/hex_hub/mcp/tools/releases.ex
+++ b/lib/hex_hub/mcp/tools/releases.ex
@@ -343,7 +343,7 @@ defmodule HexHub.MCP.Tools.Releases do
         not Map.has_key?(args, field) or is_nil(Map.get(args, field))
       end)
 
-    if length(missing_required) > 0 do
+    if missing_required != [] do
       {:error, {:missing_required_fields, missing_required}}
     else
       # Check for unknown fields
@@ -354,7 +354,7 @@ defmodule HexHub.MCP.Tools.Releases do
           field not in known_fields
         end)
 
-      if length(unknown_fields) > 0 do
+      if unknown_fields != [] do
         Telemetry.log(:warning, :mcp, "Unknown fields in args", %{
           unknown_fields: inspect(unknown_fields)
         })

--- a/lib/hex_hub/mcp/tools/repositories.ex
+++ b/lib/hex_hub/mcp/tools/repositories.ex
@@ -246,7 +246,7 @@ defmodule HexHub.MCP.Tools.Repositories do
         not Map.has_key?(args, field) or is_nil(Map.get(args, field))
       end)
 
-    if length(missing_required) > 0 do
+    if missing_required != [] do
       {:error, {:missing_required_fields, missing_required}}
     else
       # Check for unknown fields
@@ -257,7 +257,7 @@ defmodule HexHub.MCP.Tools.Repositories do
           field not in known_fields
         end)
 
-      if length(unknown_fields) > 0 do
+      if unknown_fields != [] do
         Telemetry.log(:warning, :mcp, "Unknown fields in args", %{
           unknown_fields: inspect(unknown_fields)
         })

--- a/lib/hex_hub/packages.ex
+++ b/lib/hex_hub/packages.ex
@@ -1243,79 +1243,97 @@ defmodule HexHub.Packages do
         version: version
       })
 
-      with {:ok, tarball} <- Upstream.fetch_release_tarball(package_name, version) do
+      with {:ok, tarball} <- fetch_upstream_tarball(package_name, version),
+           {:ok, release_info} <- fetch_upstream_release_info(package_name, version),
+           {:ok, _package} <- fetch_upstream_package_info(package_name) do
+        meta = extract_release_meta(release_info)
+        requirements = extract_requirements(release_info)
+        Telemetry.log(:debug, :package, "Step 5: Extracted meta and requirements")
+
+        cache_and_create_release(package_name, version, tarball, meta, requirements)
+      end
+    end
+  end
+
+  defp fetch_upstream_tarball(package_name, version) do
+    case Upstream.fetch_release_tarball(package_name, version) do
+      {:ok, tarball} ->
         Telemetry.log(:debug, :package, "Step 1: Got tarball", %{size: byte_size(tarball)})
+        {:ok, tarball}
 
-        with {:ok, releases} <- Upstream.fetch_releases(package_name) do
-          Telemetry.log(:debug, :package, "Step 2: Got releases", %{count: length(releases)})
+      {:error, reason} ->
+        Telemetry.log(:error, :package, "Step 1 failed: Failed to fetch release tarball", %{
+          reason: reason
+        })
 
-          release_info = Enum.find(releases, fn r -> r["version"] == version end)
+        {:error, :not_found}
+    end
+  end
 
-          if release_info do
-            Telemetry.log(:debug, :package, "Step 3: Found release info", %{version: version})
+  defp fetch_upstream_release_info(package_name, version) do
+    case Upstream.fetch_releases(package_name) do
+      {:ok, releases} ->
+        Telemetry.log(:debug, :package, "Step 2: Got releases", %{count: length(releases)})
 
-            with {:ok, _package} <- fetch_package_from_upstream(package_name) do
-              Telemetry.log(:debug, :package, "Step 4: Got package info")
-
-              meta = extract_release_meta(release_info)
-              requirements = extract_requirements(release_info)
-              Telemetry.log(:debug, :package, "Step 5: Extracted meta and requirements")
-
-              # Cache the tarball
-              case Upstream.cache_package(package_name, version, tarball, meta) do
-                :ok ->
-                  Telemetry.log(:debug, :package, "Step 6: Cached tarball successfully")
-                  # Create release in local database
-                  create_release_from_upstream(package_name, version, meta, requirements)
-
-                {:error, reason} ->
-                  Telemetry.log(
-                    :error,
-                    :package,
-                    "Step 6 failed: Failed to cache release tarball",
-                    %{
-                      package: package_name,
-                      version: version,
-                      reason: reason
-                    }
-                  )
-
-                  {:error, :not_found}
-              end
-            else
-              {:error, reason} ->
-                Telemetry.log(
-                  :error,
-                  :package,
-                  "Step 4 failed: Failed to fetch package from upstream",
-                  %{reason: reason}
-                )
-
-                {:error, :not_found}
-            end
-          else
+        case Enum.find(releases, fn r -> r["version"] == version end) do
+          nil ->
             Telemetry.log(:error, :package, "Step 3 failed: Version not found in releases", %{
               version: version
             })
 
             {:error, :not_found}
-          end
-        else
-          {:error, reason} ->
-            Telemetry.log(:error, :package, "Step 2 failed: Failed to fetch releases", %{
-              reason: reason
-            })
 
-            {:error, :not_found}
+          release_info ->
+            Telemetry.log(:debug, :package, "Step 3: Found release info", %{version: version})
+            {:ok, release_info}
         end
-      else
-        {:error, reason} ->
-          Telemetry.log(:error, :package, "Step 1 failed: Failed to fetch release tarball", %{
-            reason: reason
-          })
 
-          {:error, :not_found}
-      end
+      {:error, reason} ->
+        Telemetry.log(:error, :package, "Step 2 failed: Failed to fetch releases", %{
+          reason: reason
+        })
+
+        {:error, :not_found}
+    end
+  end
+
+  defp fetch_upstream_package_info(package_name) do
+    case fetch_package_from_upstream(package_name) do
+      {:ok, package} ->
+        Telemetry.log(:debug, :package, "Step 4: Got package info")
+        {:ok, package}
+
+      {:error, reason} ->
+        Telemetry.log(
+          :error,
+          :package,
+          "Step 4 failed: Failed to fetch package from upstream",
+          %{reason: reason}
+        )
+
+        {:error, :not_found}
+    end
+  end
+
+  defp cache_and_create_release(package_name, version, tarball, meta, requirements) do
+    case Upstream.cache_package(package_name, version, tarball, meta) do
+      :ok ->
+        Telemetry.log(:debug, :package, "Step 6: Cached tarball successfully")
+        create_release_from_upstream(package_name, version, meta, requirements)
+
+      {:error, reason} ->
+        Telemetry.log(
+          :error,
+          :package,
+          "Step 6 failed: Failed to cache release tarball",
+          %{
+            package: package_name,
+            version: version,
+            reason: reason
+          }
+        )
+
+        {:error, :not_found}
     end
   end
 

--- a/lib/hex_hub_admin_web/controllers/mcp_html/inspector.html.heex
+++ b/lib/hex_hub_admin_web/controllers/mcp_html/inspector.html.heex
@@ -8,8 +8,8 @@
         <span>MCP server is disabled. Enable it to run inspections.</span>
       </div>
     <% end %>
-
-    <!-- Quick Actions -->
+    
+<!-- Quick Actions -->
     <div class="grid grid-cols-auto-fill-72 gap-6 mb-8">
       <!-- Health Check -->
       <div class="card bg-surface shadow">
@@ -29,8 +29,8 @@
           </form>
         </div>
       </div>
-
-      <!-- Initialize -->
+      
+<!-- Initialize -->
       <div class="card bg-surface shadow">
         <div class="card-body">
           <h3 class="card-title text-base">
@@ -48,8 +48,8 @@
           </form>
         </div>
       </div>
-
-      <!-- List Tools -->
+      
+<!-- List Tools -->
       <div class="card bg-surface shadow">
         <div class="card-body">
           <h3 class="card-title text-base">
@@ -68,8 +68,8 @@
         </div>
       </div>
     </div>
-
-    <!-- Call Tool -->
+    
+<!-- Call Tool -->
     <div class="card bg-surface shadow-xl mb-8">
       <div class="card-body">
         <h2 class="card-title">
@@ -108,14 +108,13 @@
         </form>
       </div>
     </div>
-
-    <!-- Result -->
+    
+<!-- Result -->
     <%= if @result do %>
       <div class="card bg-surface shadow-xl">
         <div class="card-body">
           <h2 class="card-title flex items-center gap-2">
-            <.dm_mdi name="code-json" class="w-6 h-6" />
-            Result
+            <.dm_mdi name="code-json" class="w-6 h-6" /> Result
             <span class="text-sm font-normal text-on-surface-variant">
               — {@action}
             </span>
@@ -125,8 +124,8 @@
               </span>
             <% end %>
           </h2>
-
-          <!-- Status Badge -->
+          
+<!-- Status Badge -->
           <div class="mb-4">
             <%= if @result[:ok] do %>
               <span class="badge badge-success gap-1">
@@ -138,8 +137,8 @@
               </span>
             <% end %>
           </div>
-
-          <!-- Request -->
+          
+<!-- Request -->
           <%= if @result[:request] do %>
             <div class="mb-4">
               <h3 class="text-sm font-semibold text-on-surface mb-2 flex items-center gap-1.5">
@@ -151,8 +150,8 @@
               </div>
             </div>
           <% end %>
-
-          <!-- Response -->
+          
+<!-- Response -->
           <div>
             <h3 class="text-sm font-semibold text-on-surface mb-2 flex items-center gap-1.5">
               <.dm_mdi name="arrow-left-bold" class="w-4 h-4" color="var(--color-secondary)" />

--- a/lib/hex_hub_admin_web/controllers/package_html/search.html.heex
+++ b/lib/hex_hub_admin_web/controllers/package_html/search.html.heex
@@ -52,7 +52,8 @@
 <!-- Results Summary -->
   <%= if @query != "" do %>
     <div class="mb-4 flex items-center gap-2 text-sm text-on-surface-variant">
-      <.dm_mdi name="information-outline" class="h-4 w-4" /> Found {@pagination.total} package(s) matching
+      <.dm_mdi name="information-outline" class="h-4 w-4" />
+      Found {@pagination.total} package(s) matching
       "<strong>{@query}</strong>"
       <%= if @source_filter != "all" do %>
         in <span class="admin-badge admin-badge-local">{@source_filter}</span>

--- a/lib/hex_hub_admin_web/controllers/user_html/show.html.heex
+++ b/lib/hex_hub_admin_web/controllers/user_html/show.html.heex
@@ -26,7 +26,13 @@
           <.dm_btn variant="ghost" size="sm" disabled title="System users cannot be edited">
             <.dm_mdi name="pencil" class="h-4 w-4" /> Edit
           </.dm_btn>
-          <.dm_btn variant="ghost" size="sm" disabled title="System users cannot be deleted" class="text-error">
+          <.dm_btn
+            variant="ghost"
+            size="sm"
+            disabled
+            title="System users cannot be deleted"
+            class="text-error"
+          >
             <.dm_mdi name="delete" class="h-4 w-4" /> Delete
           </.dm_btn>
         <% else %>
@@ -49,8 +55,8 @@
       </div>
     </div>
   </div>
-
-  <!-- Stats -->
+  
+<!-- Stats -->
   <div class="admin-stats">
     <div class="admin-stat">
       <div class="admin-stat-icon"><.dm_mdi name="key-variant" class="h-5 w-5" /></div>
@@ -77,8 +83,8 @@
       <div class="admin-stat-label">Member Since</div>
     </div>
   </div>
-
-  <!-- User Details Panel -->
+  
+<!-- User Details Panel -->
   <div class="admin-panel mb-6">
     <div class="admin-panel-header">
       <h3>User Details</h3>
@@ -122,8 +128,8 @@
       </div>
     </div>
   </div>
-
-  <!-- API Tokens Panel -->
+  
+<!-- API Tokens Panel -->
   <div class="admin-panel mb-6">
     <div class="admin-panel-header">
       <h3>API Tokens</h3>
@@ -245,13 +251,17 @@
         </p>
       </div>
     <% end %>
-
-    <!-- Create Token Form -->
+    
+<!-- Create Token Form -->
     <div class="admin-form-section">
       <div class="admin-form-section-header">
         <h4>Create New Token</h4>
       </div>
-      <form action={~p"/users/#{@user.username}/tokens"} method="post" class="admin-form-section-body">
+      <form
+        action={~p"/users/#{@user.username}/tokens"}
+        method="post"
+        class="admin-form-section-body"
+      >
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <div class="admin-form-row">
           <div class="admin-form-field">
@@ -299,8 +309,8 @@
       </form>
     </div>
   </div>
-
-  <!-- Owned Packages Panel -->
+  
+<!-- Owned Packages Panel -->
   <div class="admin-panel">
     <div class="admin-panel-header">
       <h3>Owned Packages</h3>

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@duskmoon-dev/core": "latest",
     "@duskmoon-dev/elements": "0.11.0"
+  },
+  "overrides": {
+    "@duskmoon-dev/el-code-block": "0.11.0"
   }
 }

--- a/test/hex_hub/mcp/handler_test.exs
+++ b/test/hex_hub/mcp/handler_test.exs
@@ -220,7 +220,7 @@ defmodule HexHub.MCP.HandlerTest do
       tool_status = Handler.get_tool_status()
       assert is_list(tool_status)
 
-      if length(tool_status) > 0 do
+      if tool_status != [] do
         tool = List.first(tool_status)
         assert Map.has_key?(tool, :name)
         assert Map.has_key?(tool, :description)

--- a/test/hex_hub/mcp/server_test.exs
+++ b/test/hex_hub/mcp/server_test.exs
@@ -45,7 +45,7 @@ defmodule HexHub.MCP.ServerTest do
         {:ok, tools} ->
           assert is_list(tools)
 
-          if length(tools) > 0 do
+          if tools != [] do
             tool = List.first(tools)
             assert Map.has_key?(tool, "name")
             assert Map.has_key?(tool, "description")
@@ -200,7 +200,7 @@ defmodule HexHub.MCP.ServerTest do
       assert length(tools1) == length(tools2)
 
       # Test tool schemas are consistent
-      if length(tools1) > 0 do
+      if tools1 != [] do
         first_tool = List.first(tools1)
         {:ok, schema} = Server.get_tool_schema(first_tool["name"])
         assert schema.name == first_tool["name"]

--- a/test/hex_hub/upstream_integration_test.exs
+++ b/test/hex_hub/upstream_integration_test.exs
@@ -58,7 +58,7 @@ defmodule HexHub.UpstreamIntegrationTest do
 
         case Upstream.fetch_releases(package_name) do
           {:ok, releases} when is_list(releases) ->
-            assert length(releases) > 0
+            assert releases != []
             first_release = hd(releases)
             assert is_map(first_release)
             assert is_binary(first_release["version"])

--- a/test/hex_hub_web/controllers/mcp_public_test.exs
+++ b/test/hex_hub_web/controllers/mcp_public_test.exs
@@ -425,7 +425,7 @@ defmodule HexHubWeb.MCPPublicTest do
         assert response["error"]["code"] == -32002
         # Check retry-after header
         retry_after = get_resp_header(conn2, "retry-after")
-        assert length(retry_after) > 0
+        assert retry_after != []
       end
 
       # Reset rate limit config

--- a/test/support/admin_conn_case.ex
+++ b/test/support/admin_conn_case.ex
@@ -28,6 +28,10 @@ defmodule HexHubAdminWeb.ConnCase do
     # Clear Users test store
     HexHub.Users.reset_test_store()
 
+    # Ensure storage is reset to local for test isolation
+    Application.put_env(:hex_hub, :storage_type, :local)
+    Application.put_env(:hex_hub, :storage_path, "priv/test_storage")
+
     # Clear test storage
     test_storage_path = "priv/test_storage"
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,6 +39,10 @@ defmodule HexHubWeb.ConnCase do
     # Clear Users test store
     HexHub.Users.reset_test_store()
 
+    # Ensure storage is reset to local for test isolation
+    Application.put_env(:hex_hub, :storage_type, :local)
+    Application.put_env(:hex_hub, :storage_path, "priv/test_storage")
+
     # Clear test storage
     test_storage_path = "priv/test_storage"
 


### PR DESCRIPTION
## Summary

- **Test failures**: Moved `ExAws` `http_client: ExAws.Request.Req` config to `config.exs` (base config) so test env inherits it. Also reset `storage_type` to `:local` in `ConnCase` setup for test isolation.
- **Credo (19 warnings + 2 refactoring)**: Replaced all `length/1 > 0` comparisons with `!= []` checks. Extracted helper functions in `packages.ex` and `cached_packages.ex` to reduce nesting depth below the max of 4.
- **Format**: Ran `mix format` to fix pre-existing HEEx template formatting issues.
- **Docker build**: Added `overrides` in `package.json` to force `@duskmoon-dev/el-code-block` to `0.11.0` (version `0.10.0` required by `@duskmoon-dev/elements@0.11.0` was never published to npm).

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes with 0 issues
- [x] `mix test test/hex_hub_web/controllers/package_controller_test.exs` — 14 tests, 0 failures (previously 2 failures)
- [ ] CI workflows pass on this branch